### PR TITLE
Set default enum value for LanguageCodeEnum

### DIFF
--- a/src/PolylangTypes.php
+++ b/src/PolylangTypes.php
@@ -22,10 +22,13 @@ class PolylangTypes
             $language_codes[strtoupper($lang)] = $lang;
         }
 
-        if ( empty( $langauge_codes ) {
-           $locale = get_locale();
-           $language_codes[ strtoupper( $locale ) ] = $locale;   
-        }
+         if ( empty( $langauge_codes ) ) {
+		    $locale = get_locale();
+		    $language_codes[ strtoupper( $locale ) ] = [
+		    	'value' => $locale,
+			    'description' => __( 'The default locale of the site', 'wp-graphql-polylang' ),
+		    ];
+	    }
         
         register_graphql_enum_type('LanguageCodeEnum', [
             'description' => __(

--- a/src/PolylangTypes.php
+++ b/src/PolylangTypes.php
@@ -22,6 +22,11 @@ class PolylangTypes
             $language_codes[strtoupper($lang)] = $lang;
         }
 
+        if ( empty( $langauge_codes ) {
+           $locale = get_locale();
+           $language_codes[ strtoupper( $locale ) ] = $locale;   
+        }
+        
         register_graphql_enum_type('LanguageCodeEnum', [
             'description' => __(
                 'Enum of all available language codes',


### PR DESCRIPTION
This sets the locale of the site as the default value for the `LnguageCodeEnum` if `pll_languages_list` returns no languages.

closes #20