### PR TITLE
Typo causing default language code enum to be registered even if codes already found

### DIFF
--- a/src/PolylangTypes.php
+++ b/src/PolylangTypes.php
@@ -22,7 +22,7 @@ class PolylangTypes
             $language_codes[strtoupper($lang)] = $lang;
         }
 
-         if ( empty( $langauge_codes ) ) {
+         if ( empty( $language_codes ) ) {
 		    $locale = get_locale();
 		    $language_codes[ strtoupper( $locale ) ] = [
 		    	'value' => $locale,


### PR DESCRIPTION
When registering language codes, there is a small typo that forces the WordPress default locale to be added to the language code enums even if Polylang codes were already added.