### PR TITLE
str_replace lang codes from - to _

### DIFF
--- a/src/PolylangTypes.php
+++ b/src/PolylangTypes.php
@@ -19,7 +19,7 @@ class PolylangTypes
         $language_codes = [];
 
         foreach (pll_languages_list() as $lang) {
-            $language_codes[strtoupper($lang)] = $lang;
+            $language_codes[str_replace('-', '_', strtoupper($lang))] = $lang;
         }
 
         if (empty($language_codes)) {


### PR DESCRIPTION
Replaced - with _ in language codes

resolves error where language codes are hyphenated
`Missing onError handler for invocation 'extracting-queries', error was 'Error: Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "PT-BR" does not.'.`