### PR TITLE
Fix options page

### DIFF
--- a/src/OptionsPages.php
+++ b/src/OptionsPages.php
@@ -127,12 +127,10 @@ class OptionsPages
         /**
          * If resolving field under options page root query set the current language
          */
-        if (self::is_options_page($source)) {
-            $root_query = $info->path[0];
-            $lang = self::$root_query_locale_mapping[$root_query] ?? null;
-            if ($lang) {
-                self::$current_language = $lang;
-            }
+        $root_query = $info->path[0];
+        $lang = self::$root_query_locale_mapping[$root_query] ?? null;
+        if ($lang) {
+            self::$current_language = $lang;
         }
     }
 
@@ -176,16 +174,6 @@ class OptionsPages
         }
 
         return $id . '_' . self::$current_language;
-    }
-
-    static function is_options_page($source)
-    {
-        if (!is_array($source)) {
-            return false;
-        }
-
-        $type = $source['type'] ?? null;
-        return $type === 'options_page';
     }
 
     static function is_options_page_root_query(ResolveInfo $info)


### PR DESCRIPTION
The output of the content based on the selected language did not work because the `type `attribute was not present:

```
$type = $source['type'] ?? null;
return $type === 'options_page';
```

`$type` is always `null`.

