### PR TITLE
Fix: Ensure consistent format for language code enum values

### DIFF
--- a/src/PolylangTypes.php
+++ b/src/PolylangTypes.php
@@ -19,7 +19,10 @@ class PolylangTypes
         $language_codes = [];
 
         foreach (pll_languages_list() as $lang) {
-            $language_codes[strtoupper($lang)] = $lang;
+            // Fix: Always use the same format for values
+            $language_codes[strtoupper($lang)] = [
+                'value' => $lang,
+            ];
         }
 
         if (empty($language_codes)) {
@@ -47,11 +50,16 @@ class PolylangTypes
                 'wp-graphql-polylang'
             ),
             'values' => array_merge($language_codes, [
-                'DEFAULT' => 'default',
-                'ALL' => 'all',
+                'DEFAULT' => [
+                    'value' => 'default'
+                ],
+                'ALL' => [
+                    'value' => 'all'
+                ],
             ]),
         ]);
 
+        // Rest of the code remains the same
         register_graphql_object_type('Language', [
             'description' => __('Language (Polylang)', 'wp-graphql-polylang'),
             'fields' => [


### PR DESCRIPTION
The key changes:

1. Changed $language_codes[strtoupper($lang)] = $lang; to use the proper array format
2. Made the DEFAULT and ALL values use the same proper array format
3. 
This ensures consistency in how the enum values are structured throughout the file.