### PR TITLE
Deprecated string interpolation in PHP 8.2

### DIFF
--- a/src/PostObject.php
+++ b/src/PostObject.php
@@ -94,10 +94,10 @@ class PostObject
 
         $type = ucfirst($post_type_object->graphql_single_name);
 
-        register_graphql_fields("RootQueryTo${type}ConnectionWhereArgs", [
+        register_graphql_fields("RootQueryTo{$type}ConnectionWhereArgs", [
             'language' => [
                 'type' => 'LanguageCodeFilterEnum',
-                'description' => "Filter by ${type}s by language code (Polylang)",
+                'description' => "Filter by {$type}s by language code (Polylang)",
             ],
             'languages' => [
                 'type' => [
@@ -105,17 +105,17 @@ class PostObject
                         'non_null' => 'LanguageCodeEnum',
                     ],
                 ],
-                'description' => "Filter ${type}s by one or more languages (Polylang)",
+                'description' => "Filter {$type}s by one or more languages (Polylang)",
             ],
         ]);
 
-        register_graphql_fields("Create${type}Input", [
+        register_graphql_fields("Create{$type}Input", [
             'language' => [
                 'type' => 'LanguageCodeEnum',
             ],
         ]);
 
-        register_graphql_fields("Update${type}Input", [
+        register_graphql_fields("Update{$type}Input", [
             'language' => [
                 'type' => 'LanguageCodeEnum',
             ],

--- a/src/TermObject.php
+++ b/src/TermObject.php
@@ -54,10 +54,10 @@ class TermObject
 
         $type = ucfirst($taxonomy->graphql_single_name);
 
-        register_graphql_fields("RootQueryTo${type}ConnectionWhereArgs", [
+        register_graphql_fields("RootQueryTo{$type}ConnectionWhereArgs", [
             'language' => [
                 'type' => 'LanguageCodeFilterEnum',
-                'description' => "Filter by ${type}s by language code (Polylang)",
+                'description' => "Filter by {$type}s by language code (Polylang)",
             ],
             'languages' => [
                 'type' => [
@@ -65,16 +65,16 @@ class TermObject
                         'non_null' => 'LanguageCodeEnum',
                     ],
                 ],
-                'description' => "Filter ${type}s by one or more languages (Polylang)",
+                'description' => "Filter {$type}s by one or more languages (Polylang)",
             ],
         ]);
 
-        register_graphql_fields("Create${type}Input", [
+        register_graphql_fields("Create{$type}Input", [
             'language' => [
                 'type' => 'LanguageCodeEnum',
             ],
         ]);
-        register_graphql_fields("Update${type}Input", [
+        register_graphql_fields("Update{$type}Input", [
             'language' => [
                 'type' => 'LanguageCodeEnum',
             ],


### PR DESCRIPTION
String interpolation such as `${my_var}` is deprecated in PHP 8.2

[https://www.php.net/manual/en/migration82.deprecated.php](https://www.php.net/manual/en/migration82.deprecated.php)