### PR TITLE
Fix language detection for draft custom post types

### DIFF
--- a/src/PostObject.php
+++ b/src/PostObject.php
@@ -145,7 +145,8 @@ class PostObject
                     // The language of the preview post is not set at all so we
                     // must get the language using the original post id
                     if ($post->isPreview) {
-                        $post_id = wp_get_post_parent_id($post->ID);
+                        $post_parent_id = wp_get_post_parent_id($post->ID);
+                        $post_id = $post_parent_id ?: $post->ID; // Seems to not be needed anymore with the new versions of WP / Polylang
                     }
 
                     $slug = pll_get_post_language($post_id, 'slug');


### PR DESCRIPTION
### Problem
Draft custom post types (CPTs) were incorrectly returning `null` as their language due to improper post ID resolution

### Root Cause
When `$post->isPreview` is `true`, the code is using the ID of the Post's parent for language detection, but:
- `wp_get_post_parent_id()` was returning `0` for draft posts (that has no parents)
- The original `$post->ID` contained the correct post ID needed for language detection

### Solution

Updated the post ID resolution logic to fallback to the original post ID when no parent exists:
- `$post_id = $post_parent_id ?: $post->ID;`

This ensures that:
- For actual preview posts with parents: uses the parent ID *(though I'm not sure it really is necessary, as the `pll_get_post_language()` seems to return the correct language for preview posts)*
- For draft posts without parents: uses the original post ID