### PR TITLE
fix: Change Loader initialization to use add_action

### DIFF
--- a/wp-graphql-polylang.php
+++ b/wp-graphql-polylang.php
@@ -15,4 +15,4 @@ if (!\class_exists('\WPGraphQL\Extensions\Polylang\Loader')) {
     require_once __DIR__ . '/vendor/autoload.php';
 }
 
-\WPGraphQL\Extensions\Polylang\Loader::init();
+add_action( 'plugins_loaded', [ '\WPGraphQL\Extensions\Polylang\Loader', 'init' ] );


### PR DESCRIPTION
This ensures that WPGraphQL Polylang loads after other plugins, including core WPGraphQL are loaded. 

see: https://github.com/wp-graphql/wp-graphql/issues/3576#issuecomment-3887015023

> [!NOTE]
> I did not test this locally, so I recommend confirming this doesn't cause issues. But I believe this, or something similar to this, should fix the issue mentioned above. 